### PR TITLE
feat: return 401 on missing API key

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -25,8 +25,8 @@ DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:password@localho
 API_KEY = os.getenv("API_KEY", "your-secure-api-key-here")
 
 # API Key validation
-async def validate_api_key(x_api_key: str = Header(...)):
-    if x_api_key != API_KEY:
+async def validate_api_key(x_api_key: str | None = Header(default=None)):
+    if x_api_key is None or x_api_key != API_KEY:
         raise HTTPException(status_code=401, detail="Invalid API key")
     return True
 


### PR DESCRIPTION
## Summary
- ensure API key header is optional and returns 401 when missing or invalid

## Testing
- `python scripts/test_detection_api.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_b_68a415948d98832695b603d1870c1308