### PR TITLE
Normalize metadata handling in detection event creation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -148,10 +148,21 @@ async def create_detection_event(
             event.camera_name,
             event.image_path,
             event.alert_sent,
-            json.dumps(event.metadata)
+            event.metadata
         )
-        
-        return DetectionEvent(**dict(row))
+
+        result = {
+            "id": str(row["id"]),
+            "timestamp": row["timestamp"],
+            "person_id": row["person_id"],
+            "confidence": row["confidence"],
+            "camera_name": row["camera_name"],
+            "image_path": row["image_path"],
+            "alert_sent": row["alert_sent"],
+            "metadata": json.loads(row["metadata"]),
+        }
+
+        return DetectionEvent(**result)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
## Summary
- send metadata directly to the database and parse it after insertion
- return normalized DetectionEvent objects with string IDs and dict metadata

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_b_68a41583ec00832687aa57be48e7544d